### PR TITLE
Settings Feature: Notification Distance Control

### DIFF
--- a/ShootingApp.xcodeproj/project.pbxproj
+++ b/ShootingApp.xcodeproj/project.pbxproj
@@ -244,6 +244,12 @@
 		826FA9D72CFE07BD0029CF9C /* AppDelegate+MessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FA9D62CFE07BD0029CF9C /* AppDelegate+MessagingDelegate.swift */; };
 		826FA9D82CFE07BD0029CF9C /* AppDelegate+MessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FA9D62CFE07BD0029CF9C /* AppDelegate+MessagingDelegate.swift */; };
 		826FA9D92CFE07BD0029CF9C /* AppDelegate+MessagingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FA9D62CFE07BD0029CF9C /* AppDelegate+MessagingDelegate.swift */; };
+		826FA9DD2CFF1A770029CF9C /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FA9DC2CFF1A770029CF9C /* SettingsViewController.swift */; };
+		826FA9DE2CFF1A770029CF9C /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FA9DC2CFF1A770029CF9C /* SettingsViewController.swift */; };
+		826FA9DF2CFF1A770029CF9C /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FA9DC2CFF1A770029CF9C /* SettingsViewController.swift */; };
+		826FA9E22CFF1A9D0029CF9C /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FA9E12CFF1A9D0029CF9C /* SettingsViewModel.swift */; };
+		826FA9E32CFF1A9D0029CF9C /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FA9E12CFF1A9D0029CF9C /* SettingsViewModel.swift */; };
+		826FA9E42CFF1A9D0029CF9C /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FA9E12CFF1A9D0029CF9C /* SettingsViewModel.swift */; };
 		828545832CCCFE520074EBF9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545822CCCFE520074EBF9 /* AppDelegate.swift */; };
 		828545852CCCFE520074EBF9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545842CCCFE520074EBF9 /* SceneDelegate.swift */; };
 		8285458D2CCCFE520074EBF9 /* ShootingApp.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 8285458B2CCCFE520074EBF9 /* ShootingApp.xcdatamodeld */; };
@@ -433,6 +439,8 @@
 		826938AE2CFDA03F00E03DAA /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		826938B22CFDB00400E03DAA /* ShootingAppDebug.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ShootingAppDebug.entitlements; sourceTree = "<group>"; };
 		826FA9D62CFE07BD0029CF9C /* AppDelegate+MessagingDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+MessagingDelegate.swift"; sourceTree = "<group>"; };
+		826FA9DC2CFF1A770029CF9C /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
+		826FA9E12CFF1A9D0029CF9C /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
 		8285457F2CCCFE520074EBF9 /* ShootingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShootingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		828545822CCCFE520074EBF9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		828545842CCCFE520074EBF9 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -998,6 +1006,31 @@
 			path = Notifications;
 			sourceTree = "<group>";
 		};
+		826FA9DA2CFF1A5D0029CF9C /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				826FA9DB2CFF1A660029CF9C /* ViewControllers */,
+				826FA9E02CFF1A8E0029CF9C /* ViewModels */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
+		826FA9DB2CFF1A660029CF9C /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				826FA9DC2CFF1A770029CF9C /* SettingsViewController.swift */,
+			);
+			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		826FA9E02CFF1A8E0029CF9C /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				826FA9E12CFF1A9D0029CF9C /* SettingsViewModel.swift */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
 		828545762CCCFE520074EBF9 = {
 			isa = PBXGroup;
 			children = (
@@ -1098,6 +1131,7 @@
 				828545CB2CCD00F70074EBF9 /* Home */,
 				828545D22CCD0DA80074EBF9 /* Map */,
 				826338CE2CF0A6E1009C2CED /* Onboarding */,
+				826FA9DA2CFF1A5D0029CF9C /* Settings */,
 				8263386B2CEFB30F009C2CED /* Wallet */,
 			);
 			path = Features;
@@ -1454,6 +1488,8 @@
 				820611552CF4841C003FB6BB /* Web3ServiceProtocol.swift in Sources */,
 				820611262CF339DB003FB6BB /* WebSocketServiceDelegate.swift in Sources */,
 				8285461F2CCE46A00074EBF9 /* PlayerAnnotation.swift in Sources */,
+				826FA9E42CFF1A9D0029CF9C /* SettingsViewModel.swift in Sources */,
+				826FA9DD2CFF1A770029CF9C /* SettingsViewController.swift in Sources */,
 				8206116E2CF6A259003FB6BB /* ShotValidation.swift in Sources */,
 				828545832CCCFE520074EBF9 /* AppDelegate.swift in Sources */,
 				826938462CFA119400E03DAA /* MockWalletRepository.swift in Sources */,
@@ -1537,6 +1573,7 @@
 				826938AA2CFD99A600E03DAA /* AppDelegate+Notifications.swift in Sources */,
 				826938852CFB5E0400E03DAA /* RewardServiceProtocol.swift in Sources */,
 				820611832CF6A28D003FB6BB /* AntiCheatSystem.swift in Sources */,
+				826FA9DF2CFF1A770029CF9C /* SettingsViewController.swift in Sources */,
 				826938042CF9CA3D00E03DAA /* BaseOnboardingViewModel.swift in Sources */,
 				828545BB2CCCFF4F0074EBF9 /* CoordinatorProtocol.swift in Sources */,
 				8269387D2CFB3F1600E03DAA /* ShootFeedbackView.swift in Sources */,
@@ -1573,6 +1610,7 @@
 				826938552CFAF20E00E03DAA /* NetworkError.swift in Sources */,
 				826338712CEFB32E009C2CED /* Web3Service.swift in Sources */,
 				8269385B2CFAF21800E03DAA /* NetworkRequest.swift in Sources */,
+				826FA9E22CFF1A9D0029CF9C /* SettingsViewModel.swift in Sources */,
 				828546012CCD1B3E0074EBF9 /* MapViewController+LocationDelegate.swift in Sources */,
 				828545C62CCD00A10074EBF9 /* HomeViewModel.swift in Sources */,
 				820611322CF37EEE003FB6BB /* ErrorHandlingService.swift in Sources */,
@@ -1701,6 +1739,7 @@
 				826338D72CF0A71E009C2CED /* OnboardingCoordinator.swift in Sources */,
 				826938072CF9CA5D00E03DAA /* LocationPermissionViewModel.swift in Sources */,
 				826938682CFAF39100E03DAA /* TokenServiceProtocol.swift in Sources */,
+				826FA9E32CFF1A9D0029CF9C /* SettingsViewModel.swift in Sources */,
 				820611782CF6A269003FB6BB /* LocationValidation.swift in Sources */,
 				826938A32CFD995F00E03DAA /* NotificationManager.swift in Sources */,
 				8269388A2CFB5E3700E03DAA /* RewardResponse.swift in Sources */,
@@ -1723,6 +1762,7 @@
 				826938572CFAF20E00E03DAA /* NetworkError.swift in Sources */,
 				8206115E2CF48657003FB6BB /* AchievementsViewModel.swift in Sources */,
 				826938592CFAF21800E03DAA /* NetworkRequest.swift in Sources */,
+				826FA9DE2CFF1A770029CF9C /* SettingsViewController.swift in Sources */,
 				8285461C2CCE3E4E0074EBF9 /* StatusBarView.swift in Sources */,
 				828545A92CCCFE550074EBF9 /* ShootingAppUITestsLaunchTests.swift in Sources */,
 				820611842CF6A28D003FB6BB /* AntiCheatSystem.swift in Sources */,

--- a/ShootingApp.xcodeproj/xcuserdata/jose.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ShootingApp.xcodeproj/xcuserdata/jose.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -41,51 +41,5 @@
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "E0050EE4-1A7A-4B31-BFB9-1878B85D40EB"
-            shouldBeEnabled = "Yes"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "ShootingApp/Services/NotificationManager/NotificationManager.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "157"
-            endingLineNumber = "157"
-            landmarkName = "userNotificationCenter(_:didReceive:withCompletionHandler:)"
-            landmarkType = "7">
-            <Locations>
-               <Location
-                  uuid = "E0050EE4-1A7A-4B31-BFB9-1878B85D40EB - 2756687210af70fd"
-                  shouldBeEnabled = "Yes"
-                  ignoreCount = "0"
-                  continueAfterRunningActions = "No"
-                  symbolName = "ShootingApp.NotificationManager.userNotificationCenter(_: __C.UNUserNotificationCenter, didReceive: __C.UNNotificationResponse, withCompletionHandler: () -&gt; ()) -&gt; ()"
-                  moduleName = "ShootingApp.debug.dylib"
-                  usesParentBreakpointCondition = "Yes"
-                  urlString = "file:///Users/jose/xcode/Armen/ShootingApp/ShootingApp/Services/NotificationManager/NotificationManager.swift"
-                  startingColumnNumber = "9223372036854775807"
-                  endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "157"
-                  endingLineNumber = "157">
-               </Location>
-               <Location
-                  uuid = "E0050EE4-1A7A-4B31-BFB9-1878B85D40EB - 2096478f4d5f0827"
-                  shouldBeEnabled = "Yes"
-                  ignoreCount = "0"
-                  continueAfterRunningActions = "No"
-                  symbolName = "closure #1 (__C.UIBackgroundFetchResult) -&gt; () in ShootingApp.NotificationManager.userNotificationCenter(_: __C.UNUserNotificationCenter, didReceive: __C.UNNotificationResponse, withCompletionHandler: () -&gt; ()) -&gt; ()"
-                  moduleName = "ShootingApp.debug.dylib"
-                  usesParentBreakpointCondition = "Yes"
-                  urlString = "file:///Users/jose/xcode/Armen/ShootingApp/ShootingApp/Services/NotificationManager/NotificationManager.swift"
-                  startingColumnNumber = "9223372036854775807"
-                  endingColumnNumber = "9223372036854775807"
-                  startingLineNumber = "157"
-                  endingLineNumber = "157">
-               </Location>
-            </Locations>
-         </BreakpointContent>
-      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/ShootingApp/Coordinators/AppCoordinator.swift
+++ b/ShootingApp/Coordinators/AppCoordinator.swift
@@ -5,7 +5,6 @@
 //  Created by Jose on 26/10/2024.
 //
 
-// AppCoordinator.swift
 import UIKit
 
 final class AppCoordinator: CoordinatorProtocol {
@@ -34,6 +33,7 @@ final class AppCoordinator: CoordinatorProtocol {
     
     func showHome() {
         let homeViewController = HomeViewController(coordinator: self)
+        
         navigationController.setViewControllers([homeViewController], animated: true)
     }
     
@@ -47,6 +47,14 @@ final class AppCoordinator: CoordinatorProtocol {
         }
         
         navigationController.present(walletVC, animated: true)
+    }
+    
+    func showSettings() {
+        let viewModel = SettingsViewModel()
+        viewModel.coordinator = self
+        let settingsVC = SettingsViewController(viewModel: viewModel)
+        
+        navigationController.present(UINavigationController(rootViewController: settingsVC), animated: true)
     }
     
     func showAchievements() {

--- a/ShootingApp/Coordinators/Protocols/CoordinatorProtocol.swift
+++ b/ShootingApp/Coordinators/Protocols/CoordinatorProtocol.swift
@@ -14,6 +14,7 @@ protocol CoordinatorProtocol: AnyObject {
     
     func start()
     func showHome()
+    func showSettings()
     func showWallet()
     func showAchievements()
 }
@@ -28,9 +29,11 @@ extension CoordinatorProtocol {
     }
     
     func showHome() {
-//        let viewModel = HomeViewModel()
-//        let viewController = HomeViewController(viewModel: viewModel)
-//        navigationController.setViewControllers([viewController], animated: true)
+        // Default empty implementation
+    }
+    
+    func showSettings() {
+        // Default empty implementation
     }
     
     func showWallet() {

--- a/ShootingApp/Extensions/Notification+Names.swift
+++ b/ShootingApp/Extensions/Notification+Names.swift
@@ -9,6 +9,7 @@ import Foundation
 
 extension Notification.Name {
     static let walletConnectionChanged = Notification.Name("WalletConnectionChanged")
+    static let metamaskDidConnect = Notification.Name("MetamaskDidConnect")
     static let playerWasHit = Notification.Name("playerWasHit")
     static let playerHitTarget = Notification.Name("playerHitTarget")
     static let playerKilledTarget = Notification.Name("playerKilledTarget")
@@ -21,4 +22,5 @@ extension Notification.Name {
     static let locationDidUpdate = Notification.Name("locationDidUpdate")
     static let headingDidUpdate = Notification.Name("headingDidUpdate")
     static let playerJoined = Notification.Name("playerJoined")
+    static let notificationDistanceChanged = Notification.Name("notificationDistanceChanged")
 }

--- a/ShootingApp/Extensions/UserDefaults+Keys.swift
+++ b/ShootingApp/Extensions/UserDefaults+Keys.swift
@@ -10,5 +10,6 @@ import Foundation
 extension UserDefaults {
     enum Keys {
         static let hasSeenOnboarding = "hasSeenOnboarding"
+        static let notificationDistance = "notificationDistance"
     }
 }

--- a/ShootingApp/Features/Home/ViewControllers/HomeViewController.swift
+++ b/ShootingApp/Features/Home/ViewControllers/HomeViewController.swift
@@ -80,6 +80,17 @@ final class HomeViewController: UIViewController {
         return view
     }()
     
+    private lazy var settingsButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(UIImage(systemName: "gearshape.fill"), for: .normal)
+        button.tintColor = .white
+        button.backgroundColor = .systemBlue
+        button.layer.cornerRadius = 25
+        button.addTarget(self, action: #selector(settingsButtonTapped), for: .touchUpInside)
+        return button
+    }()
+    
     private lazy var achievementsButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -312,6 +323,7 @@ final class HomeViewController: UIViewController {
         view.addSubview(mapButton)
         view.addSubview(achievementsButton)
         view.addSubview(walletButton)
+        view.addSubview(settingsButton)
         
         topContainerView.addSubview(ammoBar)
         topContainerView.addSubview(lifeBar)
@@ -370,7 +382,12 @@ final class HomeViewController: UIViewController {
             walletButton.centerYAnchor.constraint(equalTo: shootButton.centerYAnchor),
             walletButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 16),
             walletButton.widthAnchor.constraint(equalToConstant: 50),
-            walletButton.heightAnchor.constraint(equalToConstant: 50)
+            walletButton.heightAnchor.constraint(equalToConstant: 50),
+            // Settings
+            settingsButton.centerXAnchor.constraint(equalTo: mapButton.centerXAnchor),
+            settingsButton.bottomAnchor.constraint(equalTo: achievementsButton.topAnchor, constant: -16),
+            settingsButton.widthAnchor.constraint(equalToConstant: 50),
+            settingsButton.heightAnchor.constraint(equalToConstant: 50)
         ])
         
         reloadTimerLabel.isHidden = true
@@ -523,6 +540,12 @@ final class HomeViewController: UIViewController {
     
     @objc private func walletButtonTapped() {
         viewModel.coordinator?.showWallet()
+    }
+    
+    // MARK: - settingsButtonTapped()
+    
+    @objc private func settingsButtonTapped() {
+        viewModel.coordinator?.showSettings()
     }
     
     // MARK: - achievementsButtonTapped()

--- a/ShootingApp/Features/Settings/ViewControllers/SettingsViewController.swift
+++ b/ShootingApp/Features/Settings/ViewControllers/SettingsViewController.swift
@@ -1,0 +1,130 @@
+//
+//  SettingsViewController.swift
+//  ShootingApp
+//
+//  Created by Jose on 03/12/2024.
+//
+
+import UIKit
+import Combine
+
+final class SettingsViewController: UIViewController {
+    // MARK: - Properties
+    
+    private let viewModel: SettingsViewModel
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - UI Components
+    
+    private lazy var tableView: UITableView = {
+        let table = UITableView(frame: .zero, style: .insetGrouped)
+        table.translatesAutoresizingMaskIntoConstraints = false
+        table.delegate = self
+        table.dataSource = self
+        table.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
+        return table
+    }()
+    
+    // MARK: - Initialization
+    
+    init(viewModel: SettingsViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupBindings()
+    }
+    
+    // MARK: - Setup
+    
+    private func setupUI() {
+        title = "Settings"
+        view.backgroundColor = .systemGroupedBackground
+        
+        view.addSubview(tableView)
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+    
+    private func setupBindings() {
+        viewModel.$notificationDistance
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.tableView.reloadData()
+            }
+            .store(in: &cancellables)
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension SettingsViewController: UITableViewDataSource {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "Cell", for: indexPath)
+        cell.accessoryType = .disclosureIndicator
+        
+        var content = cell.defaultContentConfiguration()
+        content.text = "Notification Distance"
+        content.secondaryText = "\(Int(viewModel.notificationDistance))m"
+        cell.contentConfiguration = content
+        
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        return "You'll receive notifications when players enter within this distance. A larger distance means more notifications but earlier warnings."
+    }
+}
+
+// MARK: - UITableViewDelegate
+
+extension SettingsViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        showDistanceSelector()
+    }
+}
+
+// MARK: - Actions
+
+private extension SettingsViewController {
+    func showDistanceSelector() {
+        let alert = UIAlertController(
+            title: "Notification Distance",
+            message: "Select the minimum distance to be notified of nearby players",
+            preferredStyle: .actionSheet
+        )
+        
+        [100, 500, 1000, 5000].forEach { distance in
+            let action = UIAlertAction(title: "\(distance)m", style: .default) { [weak self] _ in
+                self?.viewModel.updateNotificationDistance(Double(distance))
+            }
+            alert.addAction(action)
+        }
+        
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        present(alert, animated: true)
+    }
+}

--- a/ShootingApp/Features/Settings/ViewModels/SettingsViewModel.swift
+++ b/ShootingApp/Features/Settings/ViewModels/SettingsViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  SettingsViewModel.swift
+//  ShootingApp
+//
+//  Created by Jose on 03/12/2024.
+//
+
+import Foundation
+
+final class SettingsViewModel {
+    // MARK: - Properties
+    
+    @Published private(set) var notificationDistance: Double
+    weak var coordinator: AppCoordinator?
+    
+    // MARK: - Initialization
+    
+    init() {
+        self.notificationDistance = UserDefaults.standard.double(forKey: UserDefaults.Keys.notificationDistance)
+        if self.notificationDistance == 0 {
+            self.notificationDistance = 100 // Default value
+            UserDefaults.standard.set(self.notificationDistance, forKey: UserDefaults.Keys.notificationDistance)
+        }
+    }
+    
+    // MARK: - Public Methods
+    
+    func updateNotificationDistance(_ distance: Double) {
+        notificationDistance = distance
+        UserDefaults.standard.set(distance, forKey: UserDefaults.Keys.notificationDistance)
+        NotificationCenter.default.post(name: .notificationDistanceChanged, object: nil)
+    }
+}

--- a/ShootingApp/Services/GameManager/GameManager.swift
+++ b/ShootingApp/Services/GameManager/GameManager.swift
@@ -52,7 +52,7 @@ final class GameManager: GameManagerProtocol {
         
         webSocketService.delegate = self
         setupLocation()
-        setupWalletObserver()
+        setupObserver()
     }
     
     deinit {
@@ -67,13 +67,30 @@ final class GameManager: GameManagerProtocol {
     
     // MARK: - setupWalletObserver()
     
-    private func setupWalletObserver() {
+    private func setupObserver() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(updatePlayerId),
-            name: NSNotification.Name("MetaMaskDidConnect"),
+            name: .metamaskDidConnect,
             object: nil
         )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(playerJoined(_:)),
+            name: .playerJoined,
+            object: nil
+        )
+    }
+    
+    // MARK: - playerJoined(_:)
+    
+    @objc private func playerJoined(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let player = userInfo["player"] as? Player
+        else { return }
+                
+        playerManager.updatePlayer(player)
     }
     
     // MARK: - updatePlayerId()
@@ -188,6 +205,7 @@ final class GameManager: GameManagerProtocol {
     }
     
     // MARK: - sendShootConfirmation()
+    
     private func sendShootConfirmation(shotId: String, shooterId: String, distance: Double, deviation: Double) {
         guard let playerId = playerId else { return }
         
@@ -255,6 +273,7 @@ final class GameManager: GameManagerProtocol {
     }
     
     // MARK: - startGame()
+    
     func startGame() {
         startGame(retryCount: 5, retryDelay: 3.0)
     }

--- a/ShootingApp/Services/NotificationManager/NotificationManager.swift
+++ b/ShootingApp/Services/NotificationManager/NotificationManager.swift
@@ -82,33 +82,42 @@ final class NotificationManager: NSObject {
     // MARK: - handlePlayerJoined(_:)
     
     private func handlePlayerJoined(_ userInfo: [AnyHashable: Any]) {
-        guard   let id = userInfo["playerId"] as? String,
-                let lat = userInfo["latitude"] as? String,
-                let lon = userInfo["longitude"] as? String,
-                let latitude = Double(lat),
-                let longitude = Double(lon)
+        guard let id = userInfo["playerId"] as? String,
+              let lat = userInfo["latitude"] as? String,
+              let lon = userInfo["longitude"] as? String,
+              let latitude = Double(lat),
+              let longitude = Double(lon)
         else { return }
         
+        let player = Player(
+            id: id,
+            location: LocationData(
+                latitude: latitude,
+                longitude: longitude,
+                altitude: 0,
+                accuracy: 0
+            ),
+            heading: 0
+//            timestamp: Date()
+        )
+        
         let distance = LocationManager.shared.distanceFrom(latitude: latitude, longitude: longitude)
+        let notificationDistance = UserDefaults.standard.double(forKey: UserDefaults.Keys.notificationDistance)
         
-        guard distance < 1000 && distance > 10 else { return }
-        
-        print("playerId: \(id)")
+        guard distance < notificationDistance && distance > 1 else { return }
         
         NotificationCenter.default.post(
             name: .playerJoined,
             object: nil,
             userInfo: [
-                "playerId": id,
-                "latitude": latitude,
-                "longitude": longitude,
+                "player": player,
                 "distance": Int(distance)
             ]
         )
         
         let content = UNMutableNotificationContent()
         content.title = "Player Nearby!"
-        content.body = "New player is \(Int(distance))m away"
+        content.body = "\(Int(distance))m away"
         content.sound = .default
         
         let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: nil)

--- a/ShootingApp/Services/WebSocket/WebSocketService.swift
+++ b/ShootingApp/Services/WebSocket/WebSocketService.swift
@@ -10,13 +10,13 @@ import Foundation
 class WebSocketService {
     // MARK: - Constants
     
-#if targetEnvironment(simulator)
-    private let serverURL = URL(string: "ws://localhost:8182")!
-#elseif DEBUG
-    private let serverURL = URL(string: "ws://192.168.0.102:8182")!
-#else
+//#if targetEnvironment(simulator)
+//    private let serverURL = URL(string: "ws://localhost:8182")!
+//#elseif DEBUG
+//    private let serverURL = URL(string: "ws://192.168.0.102:8182")!
+//#else
     private let serverURL = URL(string: "ws://onedayvpn.com:8182")!
-#endif
+//#endif
     private let reconnectDelay: TimeInterval = 3.0
     private let maxReconnectAttempts = 5
 


### PR DESCRIPTION
# Settings Feature: Notification Distance Control

## Changes Made
- Added settings button to HomeViewController
- Created SettingsViewController with native iOS settings style
- Implemented notification distance control (100m-5000m range)
- Added UserDefaults persistence for settings
- Integrated with NotificationManager for player proximity alerts

## Technical Details
- Added new Settings module following MVVM-C architecture
- Implemented UITableView with inset grouped style
- Used UserDefaults for settings persistence
- Added notification distance observer system
- Updated NotificationManager to respect distance settings

## Implementation Notes
- Default notification distance: 100m
- Available distances: 100m, 500m, 1000m, 5000m
- Uses action sheet for distance selection
- Added explanatory footer text for setting
- Updates take effect immediately via NotificationCenter

## Testing
- Settings view presentation
- Distance selection persistence
- NotificationManager integration
- Real-time setting updates

## Related Changes
- Updated NotificationManager to use configured distance
- Added new notification name for distance changes
- Extended AppCoordinator for settings navigation
- Added settings icon to HomeViewController

## UI/UX
- Settings gear icon in home screen
- Native iOS settings style
- Inset grouped table view
- Disclosure indicators
- Action sheet selection