### PR TITLE
Fix Alert and Thread Issues in Home Screen

### DIFF
--- a/ShootingApp.xcodeproj/project.pbxproj
+++ b/ShootingApp.xcodeproj/project.pbxproj
@@ -283,6 +283,12 @@
 		826FAA192D0088FB0029CF9C /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FAA182D0088FB0029CF9C /* EmptyStateView.swift */; };
 		826FAA1A2D0088FB0029CF9C /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FAA182D0088FB0029CF9C /* EmptyStateView.swift */; };
 		826FAA1B2D0088FB0029CF9C /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FAA182D0088FB0029CF9C /* EmptyStateView.swift */; };
+		826FAA1E2D0094DA0029CF9C /* AlertHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FAA1D2D0094DA0029CF9C /* AlertHandlerProtocol.swift */; };
+		826FAA1F2D0094DA0029CF9C /* AlertHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FAA1D2D0094DA0029CF9C /* AlertHandlerProtocol.swift */; };
+		826FAA202D0094DA0029CF9C /* AlertHandlerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FAA1D2D0094DA0029CF9C /* AlertHandlerProtocol.swift */; };
+		826FAA222D0095010029CF9C /* HomeViewController+AlertHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FAA212D0095010029CF9C /* HomeViewController+AlertHandler.swift */; };
+		826FAA232D0095010029CF9C /* HomeViewController+AlertHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FAA212D0095010029CF9C /* HomeViewController+AlertHandler.swift */; };
+		826FAA242D0095010029CF9C /* HomeViewController+AlertHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 826FAA212D0095010029CF9C /* HomeViewController+AlertHandler.swift */; };
 		828545832CCCFE520074EBF9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545822CCCFE520074EBF9 /* AppDelegate.swift */; };
 		828545852CCCFE520074EBF9 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 828545842CCCFE520074EBF9 /* SceneDelegate.swift */; };
 		8285458D2CCCFE520074EBF9 /* ShootingApp.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 8285458B2CCCFE520074EBF9 /* ShootingApp.xcdatamodeld */; };
@@ -485,6 +491,8 @@
 		826FAA0F2D00809F0029CF9C /* AchievementsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AchievementsCoordinator.swift; sourceTree = "<group>"; };
 		826FAA132D0084FE0029CF9C /* SettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinator.swift; sourceTree = "<group>"; };
 		826FAA182D0088FB0029CF9C /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		826FAA1D2D0094DA0029CF9C /* AlertHandlerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertHandlerProtocol.swift; sourceTree = "<group>"; };
+		826FAA212D0095010029CF9C /* HomeViewController+AlertHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HomeViewController+AlertHandler.swift"; sourceTree = "<group>"; };
 		8285457F2CCCFE520074EBF9 /* ShootingApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShootingApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		828545822CCCFE520074EBF9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		828545842CCCFE520074EBF9 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -1123,6 +1131,14 @@
 			path = Views;
 			sourceTree = "<group>";
 		};
+		826FAA1C2D0094BE0029CF9C /* Protocols */ = {
+			isa = PBXGroup;
+			children = (
+				826FAA1D2D0094DA0029CF9C /* AlertHandlerProtocol.swift */,
+			);
+			path = Protocols;
+			sourceTree = "<group>";
+		};
 		828545762CCCFE520074EBF9 = {
 			isa = PBXGroup;
 			children = (
@@ -1236,6 +1252,7 @@
 		828545CB2CCD00F70074EBF9 /* Home */ = {
 			isa = PBXGroup;
 			children = (
+				826FAA1C2D0094BE0029CF9C /* Protocols */,
 				828545CC2CCD00FF0074EBF9 /* ViewControllers */,
 				828545CD2CCD01080074EBF9 /* ViewModels */,
 				8285461D2CCE3E820074EBF9 /* Views */,
@@ -1249,6 +1266,7 @@
 				828545C02CCD007B0074EBF9 /* HomeViewController.swift */,
 				828546042CCD203A0074EBF9 /* HomeViewController+LocationDelegate.swift */,
 				826937F62CF8D78A00E03DAA /* HomeViewController+VisionDebug.swift */,
+				826FAA212D0095010029CF9C /* HomeViewController+AlertHandler.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -1577,6 +1595,7 @@
 				8269383D2CFA112F00E03DAA /* WalletRepository.swift in Sources */,
 				826938902CFB5FDA00E03DAA /* RewardRequest.swift in Sources */,
 				820611A32CF6A9C5003FB6BB /* CVPixelBuffer+Copy.swift in Sources */,
+				826FAA1F2D0094DA0029CF9C /* AlertHandlerProtocol.swift in Sources */,
 				820611952CF6A38A003FB6BB /* MockAntiCheatSystem.swift in Sources */,
 				828545BA2CCCFF4F0074EBF9 /* CoordinatorProtocol.swift in Sources */,
 				828545F72CCD16920074EBF9 /* PlayerManager.swift in Sources */,
@@ -1590,6 +1609,7 @@
 				826FA9F52D007D450029CF9C /* HallOfFameResponse.swift in Sources */,
 				8206116E2CF6A259003FB6BB /* ShotValidation.swift in Sources */,
 				828545832CCCFE520074EBF9 /* AppDelegate.swift in Sources */,
+				826FAA232D0095010029CF9C /* HomeViewController+AlertHandler.swift in Sources */,
 				826FAA102D00809F0029CF9C /* AchievementsCoordinator.swift in Sources */,
 				826938462CFA119400E03DAA /* MockWalletRepository.swift in Sources */,
 				828546052CCD203A0074EBF9 /* HomeViewController+LocationDelegate.swift in Sources */,
@@ -1699,6 +1719,7 @@
 				826938412CFA114500E03DAA /* WalletRepositoryProtocol.swift in Sources */,
 				828546292CCE46DB0074EBF9 /* PlayerAnnotationView.swift in Sources */,
 				826FAA112D00809F0029CF9C /* AchievementsCoordinator.swift in Sources */,
+				826FAA242D0095010029CF9C /* HomeViewController+AlertHandler.swift in Sources */,
 				826938672CFAF39100E03DAA /* TokenServiceProtocol.swift in Sources */,
 				826338DC2CF1D996009C2CED /* UserDefaults+Keys.swift in Sources */,
 				826FA9F92D007D7C0029CF9C /* HallOfFameRequest.swift in Sources */,
@@ -1770,6 +1791,7 @@
 				820611872CF6A298003FB6BB /* HitValidationSystem.swift in Sources */,
 				826938632CFAF29400E03DAA /* NetworkClientProtocol.swift in Sources */,
 				820611612CF48673003FB6BB /* AchievementsViewController.swift in Sources */,
+				826FAA1E2D0094DA0029CF9C /* AlertHandlerProtocol.swift in Sources */,
 				820611432CF48217003FB6BB /* AchievementType.swift in Sources */,
 				820611222CF33685003FB6BB /* GameManagerProtocol.swift in Sources */,
 				826938372CFA107600E03DAA /* KeychainManager.swift in Sources */,
@@ -1821,6 +1843,7 @@
 				828545F92CCD16920074EBF9 /* PlayerManager.swift in Sources */,
 				820611572CF4841C003FB6BB /* Web3ServiceProtocol.swift in Sources */,
 				826FA9FC2D007DE60029CF9C /* HallOfFameService.swift in Sources */,
+				826FAA202D0094DA0029CF9C /* AlertHandlerProtocol.swift in Sources */,
 				820611122CF1F453003FB6BB /* WalletUITest.swift in Sources */,
 				826938812CFB462000E03DAA /* FeedbackView.swift in Sources */,
 				826338742CEFB332009C2CED /* Web3Error.swift in Sources */,
@@ -1835,6 +1858,7 @@
 				820611742CF6A260003FB6BB /* HitValidation.swift in Sources */,
 				826338702CEFB322009C2CED /* WalletViewModel.swift in Sources */,
 				8269381C2CF9CBD900E03DAA /* WalletConnectionViewController.swift in Sources */,
+				826FAA222D0095010029CF9C /* HomeViewController+AlertHandler.swift in Sources */,
 				826FA9D92CFE07BD0029CF9C /* AppDelegate+MessagingDelegate.swift in Sources */,
 				828545FD2CCD18680074EBF9 /* MapViewModel.swift in Sources */,
 				826FAA122D00809F0029CF9C /* AchievementsCoordinator.swift in Sources */,

--- a/ShootingApp.xcodeproj/xcuserdata/jose.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/ShootingApp.xcodeproj/xcuserdata/jose.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -41,5 +41,37 @@
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "A5D06DD8-63DB-4167-8150-DE0D2C12B375"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "ShootingApp/Features/Wallet/ViewModels/WalletViewModel.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "43"
+            endingLineNumber = "43"
+            landmarkName = "checkConnection()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "E641EDAB-8502-48D0-97A3-AB114FAF25B1"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "ShootingApp/Features/Wallet/ViewModels/WalletViewModel.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "40"
+            endingLineNumber = "40"
+            landmarkName = "checkConnection()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/ShootingApp/Features/Achievements/ViewControllers/AchievementsViewController.swift
+++ b/ShootingApp/Features/Achievements/ViewControllers/AchievementsViewController.swift
@@ -52,7 +52,7 @@ final class AchievementsViewController: UIViewController {
     private func setupNavigationBar() {
         navigationItem.title = "Achievements"
         navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: "Hall of Fame",
+            title: "HallOfFame",
             style: .plain,
             target: self,
             action: #selector(hallOfFameTapped)

--- a/ShootingApp/Features/Home/Protocols/AlertHandlerProtocol.swift
+++ b/ShootingApp/Features/Home/Protocols/AlertHandlerProtocol.swift
@@ -1,0 +1,13 @@
+//
+//  AlertHandlerProtocol.swift
+//  ShootingApp
+//
+//  Created by Jose on 04/12/2024.
+//
+
+import Foundation
+
+protocol AlertHandlerProtocol {
+    func showTimerOrAdAlert(title: String, message: String, completion: (()->())?)
+    func startTimer(duration: Int, completion: (()->())?)
+}

--- a/ShootingApp/Features/Home/ViewControllers/HomeViewController+AlertHandler.swift
+++ b/ShootingApp/Features/Home/ViewControllers/HomeViewController+AlertHandler.swift
@@ -1,0 +1,64 @@
+//
+//  HomeViewController+AlertHandler.swift
+//  ShootingApp
+//
+//  Created by Jose on 04/12/2024.
+//
+
+import UIKit
+
+extension HomeViewController {
+    class HomeAlertHandler: AlertHandlerProtocol {
+        weak var viewController: HomeViewController?
+        
+        init(viewController: HomeViewController) {
+            self.viewController = viewController
+        }
+        
+        func showTimerOrAdAlert(title: String, message: String, completion: (()->())? = nil) {
+            guard let viewController else { return }
+            
+            // If another VC is presented, start timer directly
+            if viewController.presentedViewController != nil {
+                startTimer(duration: 60, completion: completion)
+                return
+            }
+            
+            let alert = UIAlertController(title: title, message: message, preferredStyle: .actionSheet)
+            let timer = UIAlertAction(title: "Timer", style: .default) { [weak self] _ in
+                self?.startTimer(duration: 60, completion: completion)
+            }
+            let ad = UIAlertAction(title: "Ad", style: .default) { [weak self] _ in
+                guard let self else { return }
+                Task {
+                    await viewController.loadRewardedAd()
+                    completion?()
+                }
+            }
+            
+            alert.addAction(timer)
+            alert.addAction(ad)
+            viewController.present(alert, animated: true)
+        }
+        
+        func startTimer(duration: Int, completion: (()->())? = nil) {
+            guard let viewController else { return }
+            
+            var timeLeft = duration
+            viewController.reloadTimerLabel.isHidden = false
+            viewController.reloadTimerLabel.text = "\(timeLeft)"
+            
+            Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak viewController] timer in
+                guard let viewController else { return }
+                
+                viewController.reloadTimerLabel.text = "\(timeLeft)"
+                
+                if timeLeft <= 0 {
+                    timer.invalidate()
+                    completion?()
+                }
+                timeLeft -= 1
+            }
+        }
+    }
+}

--- a/ShootingApp/Features/Wallet/ViewControllers/WalletViewController.swift
+++ b/ShootingApp/Features/Wallet/ViewControllers/WalletViewController.swift
@@ -26,7 +26,6 @@ final class WalletViewController: UIViewController {
         label.numberOfLines = 2
         label.lineBreakMode = .byTruncatingMiddle
         label.font = .systemFont(ofSize: 20)
-        label.isHidden = true
         return label
     }()
     
@@ -135,6 +134,7 @@ final class WalletViewController: UIViewController {
             .store(in: &cancellables)
         
         viewModel.$accountAddress
+            .compactMap({$0})
             .receive(on: DispatchQueue.main)
             .sink { [weak self] address in
                 guard let self else { return }
@@ -181,11 +181,9 @@ final class WalletViewController: UIViewController {
         connectButton.setTitle(isConnected ? "Disconnect MetaMask" : "Connect MetaMask", for: .normal)
     }
     
-    private func updateAccountLabel(address: String?) {
-        accountLabel.isHidden = address == nil
-        if let address = address {
-            accountLabel.text = "Connected to:\n\(address)"
-        }
+    private func updateAccountLabel(address: String) {
+        let wording = viewModel.isConnected ? "Connected to:" : "Temporary address:"
+        accountLabel.text = "\(wording)\n\(address)"
     }
     
     private func showMetaMaskNotInstalledAlert() {

--- a/ShootingApp/Features/Wallet/ViewModels/WalletViewModel.swift
+++ b/ShootingApp/Features/Wallet/ViewModels/WalletViewModel.swift
@@ -39,11 +39,15 @@ final class WalletViewModel: ObservableObject  {
             isConnected = true
             accountAddress = web3Service.account
         }
+        else {
+            isConnected = false
+            accountAddress = GameManager.shared.playerId
+        }
     }
     
     private func checkExistingConnection() {
         isConnected = web3Service.isConnected
-        accountAddress = web3Service.account
+        accountAddress = web3Service.account ?? GameManager.shared.playerId
     }
     
     func connect() async {
@@ -58,7 +62,7 @@ final class WalletViewModel: ObservableObject  {
             accountAddress = account
         } catch {
             isConnected = false
-            accountAddress = nil
+            accountAddress = GameManager.shared.playerId
             self.error = error
         }
     }
@@ -66,7 +70,7 @@ final class WalletViewModel: ObservableObject  {
     func disconnect() {
         web3Service.disconnect()
         isConnected = false
-        accountAddress = nil
+        accountAddress = GameManager.shared.playerId
     }
     
     func openAppStore() {


### PR DESCRIPTION
# Fix Alert and Thread Issues in Home Screen

## Changes
- Fixed issue with alert not showing when killed with wallet open by skipping alert and showing timer directly
- Resolved crash when updating UI on background thread
- Created AlertHandler protocol to improve alert handling architecture
- Moved alert functionality to dedicated handler class

## Technical Changes
- Added dispatch to main thread for UI updates in `finishRecovering()`
- Created `AlertHandler` protocol and `HomeAlertHandler` implementation
- Added check for presented view controllers before showing alerts
- Moved timer functionality to alert handler

## Testing
- [ ] Test getting killed with wallet open - should show timer directly
- [ ] Test getting killed with no modals - should show alert
- [ ] Test timer functionality still works
- [ ] Test ad functionality still works
- [ ] Verify no UI-related crashes