### PR TITLE
Network Security & Configuration Updates

### DIFF
--- a/ShootingApp.xcodeproj/project.pbxproj
+++ b/ShootingApp.xcodeproj/project.pbxproj
@@ -1434,11 +1434,11 @@
 				828546082CCE356F0074EBF9 /* CLLocation+Bearing.swift */,
 				8285460C2CCE35A00074EBF9 /* Double+DegreesToRadians.swift */,
 				828546112CCE376B0074EBF9 /* Notification+Names.swift */,
+				82381EAA2D05D4F7008FBD86 /* UIColor+Custom.swift */,
 				826338CC2CF0A55F009C2CED /* URL+QueryParameters.swift */,
 				826338DA2CF1D996009C2CED /* UserDefaults+Keys.swift */,
 				8269382D2CF9CEC200E03DAA /* CVPixelBuffer */,
 				8269387A2CFB36B100E03DAA /* UIViewController */,
-				82381EAA2D05D4F7008FBD86 /* UIColor+Custom.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";

--- a/ShootingApp/Info.plist
+++ b/ShootingApp/Info.plist
@@ -25,21 +25,6 @@
 	<array>
 		<string>metamask</string>
 	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>onedayvpn.com</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-				<key>NSIncludesSubdomains</key>
-				<true/>
-			</dict>
-		</dict>
-	</dict>
 	<key>SKAdNetworkItems</key>
 	<array>
 		<dict>

--- a/ShootingApp/Services/Network/Environment.swift
+++ b/ShootingApp/Services/Network/Environment.swift
@@ -36,10 +36,10 @@ struct Environment {
     }()
     
     static var apiURL: URL {
-        URL(string: "http://\(baseURL):\(apiPort)")!
+        URL(string: "https://\(baseURL)")!
     }
     
     static var socketURL: URL {
-        URL(string: "ws://\(baseURL):\(socketPort)")!
+        URL(string: "wss://\(baseURL):\(socketPort)")!
     }
 }

--- a/ShootingApp/URLs.plist
+++ b/ShootingApp/URLs.plist
@@ -1,19 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<!--
-   URLs.plist
-   ShootingApp
-
-   Created by Jose on 07/12/2024.
--->
-
 <plist version="1.0">
-    <dict>
-        <key>BaseURL</key>
-        <string>onedayvpn.com</string>
-        <key>APIPort</key>
-        <integer>3000</integer>
-        <key>SocketPort</key>
-        <integer>8182</integer>
-    </dict>
+<dict>
+	<key>BaseURL</key>
+	<string>api.shootingdapp.com</string>
+	<key>APIPort</key>
+	<integer>80</integer>
+	<key>SocketPort</key>
+	<integer>8182</integer>
+</dict>
 </plist>


### PR DESCRIPTION
# Changelog

## Network Security & Configuration Updates

### API Security Improvements
- Changed API endpoints from HTTP to HTTPS
- Changed WebSocket connections from WS to WSS (secure WebSocket)
- Removed insecure HTTP exception for `onedayvpn.com` from Info.plist
- Updated base URL from `onedayvpn.com` to `api.shootingdapp.com`

### Port Configuration
- Modified API port configuration:
  - Previous: Port 3000
  - Current: Port 80 (standard HTTP/HTTPS port)
- WebSocket port remains unchanged at 8182

### File Structure Changes
- Reorganized Extensions directory structure in XCode project
- Moved `UIColor+Custom.swift` file to improve file organization

### Metadata Updates
- Cleaned up URLs.plist file by removing redundant comments and metadata

## Additional Information
These changes represent a significant security upgrade by enforcing HTTPS/WSS protocols and removing insecure HTTP allowances. The migration from `onedayvpn.com` to `api.shootingdapp.com` suggests a move to a more application-specific API endpoint.