### PR TITLE
Drone Timeout Implementation

### DIFF
--- a/ShootingApp/Extensions/Notification+Names.swift
+++ b/ShootingApp/Extensions/Notification+Names.swift
@@ -26,5 +26,5 @@ extension Notification.Name {
     static let notificationDistanceChanged = Notification.Name("notificationDistanceChanged")
     static let websocketStatusChanged = Notification.Name("websocketStatusChanged")
     static let newDroneArrived = Notification.Name("newDroneArrived")
-
+    static let removeAllDrones = Notification.Name("removeAllDrones")
 }

--- a/ShootingApp/Features/Home/ViewControllers/HomeViewController.swift
+++ b/ShootingApp/Features/Home/ViewControllers/HomeViewController.swift
@@ -801,6 +801,8 @@ final class HomeViewController: UIViewController {
         }
     }
     
+    // MARK: - showOnboardingIfNeeded()
+    
     private func showOnboardingIfNeeded() {
         if let viewController = OnboardingSheetViewController(configuration: .home) {
             viewController.additionalSafeAreaInsets.top = 3
@@ -834,7 +836,6 @@ extension HomeViewController {
         updateWalletButtonState()
     }
 }
-
 
 // MARK: - Google Ads
 

--- a/ShootingApp/Models/Domain/GameMessage.swift
+++ b/ShootingApp/Models/Domain/GameMessage.swift
@@ -21,6 +21,7 @@ struct GameMessage: Codable {
         case announced
         case droneShootConfirmed
         case droneShootRejected
+        case removeDrones
     }
     
     let type: MessageType


### PR DESCRIPTION
# Drone Timeout Implementation

## Overview
This PR implements a timeout mechanism for drones in the AR game. Drones will now automatically be removed after 1 minute of inactivity if they haven't been shot.

## Key Changes
- Added drone timeout mechanism (60 seconds)
- Improved AR scene management for drone removal
- Added new notification type for drone removal
- Enhanced zoom functionality in AR view

## Technical Details
### Game Manager
- Added drone timer management
- New `resetDroneTimer` method to handle drone lifecycle
- Implemented `removeDrones` functionality to communicate with server

### AR Scene Manager
- Added proper cleanup of drone nodes
- Improved memory management by clearing geometries
- Enhanced thread safety with main queue dispatching
- Fixed zoom transformation implementation

### Notifications
- Added new `removeAllDrones` notification type
- Implemented observers for drone removal events

## Testing
Please verify:
- Drones disappear after 1 minute of inactivity
- Shooting a drone properly removes it from the scene
- Zoom functionality works smoothly
- Scene updates correctly when drones are removed

## Notes
- Timer resets when new drones appear
- Timer cancels when a drone is shot
- All scene modifications happen on the main thread